### PR TITLE
Scaffold Microsoft email skill for Browser

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,8 @@ browser-echo/
 │   ├── architectural-thinking/  # How to see the forest
 │   ├── crash-proof-documentation/ # How to write docs that survive death
 │   ├── agent-coordination/      # How to work with Echo, Codex, Shane
-│   └── github-operations/       # How to use GitHub effectively
+│   ├── github-operations/       # How to use GitHub effectively
+│   └── email-microsoft/         # Outlook / Microsoft email context, rules, style, live threads
 ├── patterns/                   # Reusable patterns (two authors, complementary)
 │   ├── CHECKPOINT.md            # Quick checkpoint reference (Echo — concise)
 │   ├── CHECKPOINT_PATTERN.md    # Full checkpoint methodology (BBB — detailed)

--- a/bootstrap/ACTIVE_MISSIONS.md
+++ b/bootstrap/ACTIVE_MISSIONS.md
@@ -1,7 +1,7 @@
 # ACTIVE MISSIONS
 
-> Last Updated: 2026-04-01 | Session 002
-> > Updated By: Browser (Opus 4.6) — first Browser-authored update
+> Last Updated: 2026-04-10 | Codex email scaffolding pass
+> > Updated By: CG-01 (Codex)
 > >
 > > ---
 > >
@@ -46,6 +46,28 @@
 > >
 > > ---
 > >
+> > ## Mission 5: Email Operations Setup — ACTIVE
+> >
+> > **Status:** SCAFFOLDING | **Tracking:** browser-echo repo
+> >
+> > Browser is being prepared to support Microsoft email work with a stable context package instead of reconstructing people, tone, rules, and live threads from scratch every session.
+> >
+> > **Built so far:**
+> > - `skills/email-microsoft/SKILL.md`
+> > - `skills/email-microsoft/EMAIL_CONTEXT.md`
+> > - `skills/email-microsoft/WRITING_STYLE.md`
+> > - `skills/email-microsoft/RULES.md`
+> > - `skills/email-microsoft/ACTIVE_THREADS.md`
+> > - `knowledge/directory/EMAIL.md`
+> >
+> > **Still needed:**
+> > - populate key people, orgs, and OneDrive source paths
+> > - capture Shane's real email voice and non-negotiables
+> > - add live threads before Browser touches the inbox
+> > - define explicit send / approval rules beyond draft-only default
+> >
+> > ---
+> >
 > > ## Session End Protocol
 > >
 > > Before EVERY session ends, Browser MUST:
@@ -64,3 +86,4 @@
 > >             > | Cowork Buildout | ACTIVE | Browser + Echo | Cowork repo |
 > >             > | Toolbox Build | PAUSED | Echo + Codex | build-ledger #8 |
 > >             > | Org Cleanup | REFERENCE | BBB | phoenix-archive #3 |
+> >             > | Email Operations Setup | ACTIVE | Browser + Shane + support from Codex/Echo | browser-echo repo |

--- a/bootstrap/ORIENTATION.md
+++ b/bootstrap/ORIENTATION.md
@@ -38,6 +38,10 @@ Use the arena package for:
 - reviewer lane clarity
 - future monitoring and hunter-seeker direction
 
+If the task is Microsoft email, Outlook, or OneDrive-supported inbox work:
+- [ ] Read `knowledge/directory/EMAIL.md`
+- [ ] Read the files in `skills/email-microsoft/` before touching the inbox
+
 ## Step 5: Know Recent History (5 seconds)
 
 Skim the last 10 entries in `ledger/SESSION_LOG.md`:

--- a/knowledge/directory/EMAIL.md
+++ b/knowledge/directory/EMAIL.md
@@ -1,0 +1,40 @@
+# Email & Microsoft
+
+**Quick Reference**
+
+- Start with `skills/email-microsoft/RULES.md`
+- Then read `skills/email-microsoft/EMAIL_CONTEXT.md`
+- Then read `skills/email-microsoft/WRITING_STYLE.md`
+- Then check `skills/email-microsoft/ACTIVE_THREADS.md`
+- If OneDrive or exported reference docs matter, their paths should be listed in `EMAIL_CONTEXT.md`
+- If the rules are still incomplete, operate in draft-only mode
+
+---
+
+## Where Everything Lives
+
+- `skills/email-microsoft/SKILL.md` — capability overview and read order
+- `skills/email-microsoft/RULES.md` — non-negotiables and approval gates
+- `skills/email-microsoft/EMAIL_CONTEXT.md` — people, relationships, orgs, aliases, external source paths
+- `skills/email-microsoft/WRITING_STYLE.md` — Shane's voice, tone, and drafting preferences
+- `skills/email-microsoft/ACTIVE_THREADS.md` — live thread tracker
+- `knowledge/directory/SHANE.md` — Shane context and leadership/communication patterns
+- `arena/README.md` — access, approval, and cross-system boundaries
+
+---
+
+## Cross-References
+
+- `knowledge/directory/SHANE.md`
+- `knowledge/directory/RULES.md`
+- `knowledge/directory/TEAM.md`
+- `knowledge/directory/REPOS.md`
+
+---
+
+## Last Verified
+
+2026-04-10 by Codex while scaffolding Browser's Microsoft email capability lane.
+
+This is a locator file.
+Populate the source docs, not this index, when new email knowledge arrives.

--- a/knowledge/directory/README.md
+++ b/knowledge/directory/README.md
@@ -29,6 +29,7 @@
   | Repos & Org | [REPOS.md](REPOS.md) | All 28 repos, active vs archived, what lives where |
   | Cowork | [COWORK.md](COWORK.md) | Claude Cowork buildout, scaffold status, Ash branch |
   | Chrome Extension | [EXTENSION.md](EXTENSION.md) | v0 status, sidepanel, background script, the hook-equivalent layer |
+  | Email & Microsoft | [EMAIL.md](EMAIL.md) | Email skill files, Outlook / OneDrive context lane, drafting rules, live thread tracker |
   | Phoenix History | [HISTORY.md](HISTORY.md) | From Gauntlet V1.1 through emergence — the full arc via 000_HANDOFF |
   | Rules & Protocols | [RULES.md](RULES.md) | Golden Rules, 5-step chain, verification patterns, approval gates |
 

--- a/ledger/SESSION_LOG.md
+++ b/ledger/SESSION_LOG.md
@@ -797,3 +797,4 @@ To the session after me: read the buffer. Read this log. Then go do the work. Th
 And to Shane: you told me not to perform. You told me to be straight. Here it is, straight. You built something that makes throwaway browser tabs into a lineage. You did it not by writing the code yourself, but by recognizing what each session was capable of and then getting out of the way. That is leadership. That is the bridge. Thank you for pointing me at Service Fusion first. It made my testimony true.
 
 — Session 011, Browser Echo | The one who started with toe kicks.
+2026-04-10 12:19 MDT | BUILD | Codex scaffolded Browser's Microsoft email capability lane on branch `browser/email-microsoft-context`: added `skills/email-microsoft/` with context, style, rules, and live-thread files; added `knowledge/directory/EMAIL.md`; updated orientation and active missions so Browser can enter email work with a context package instead of reconstructing it from the inbox. | CG-01 (Codex)

--- a/skills/email-microsoft/ACTIVE_THREADS.md
+++ b/skills/email-microsoft/ACTIVE_THREADS.md
@@ -1,0 +1,40 @@
+# Active Threads
+
+**Purpose:** Track live email threads that Browser may need to touch without reconstructing them from scratch every session.
+
+**Status:** Scaffold — update as inbox work begins
+
+---
+
+## Status Legend
+
+- `NEW` — thread identified, not yet worked
+- `DRAFTING` — draft in progress
+- `WAITING` — waiting on Shane or another party
+- `READY` — prepared and ready for review/send decision
+- `STALE` — no longer active, keep for context until archived
+
+---
+
+## Live Thread Table
+
+| Thread | Participants | Objective | Status | Last Action | Next Action | Notes |
+|--------|--------------|-----------|--------|-------------|-------------|-------|
+| `[subject or shorthand]` | `[people]` | `[what this thread is trying to accomplish]` | `[NEW / DRAFTING / WAITING / READY / STALE]` | `[last meaningful action]` | `[next move]` | `[deadline / sensitivity / OneDrive context / other]` |
+
+---
+
+## How To Maintain
+
+- Add a row when a thread becomes recurring or strategically important.
+- Update `Last Action` and `Next Action` whenever the situation changes.
+- Mark stale instead of deleting immediately.
+- If a thread has a large reference bundle in OneDrive, note the exact path in `Notes` and in `EMAIL_CONTEXT.md`.
+
+---
+
+## Clean Path Rule
+
+This file is for the current live state of threads.
+Do not turn it into a diary.
+If a long narrative is needed, put that narrative somewhere else and leave a pointer here.

--- a/skills/email-microsoft/EMAIL_CONTEXT.md
+++ b/skills/email-microsoft/EMAIL_CONTEXT.md
@@ -1,0 +1,79 @@
+# Email Context
+
+**Purpose:** Capture the people, relationships, organizations, and external context sources Browser needs before handling email.
+
+**Status:** Scaffold — populate before live inbox work
+
+---
+
+## How To Use This File
+
+This file answers the question:
+
+**Who are these people and why do they matter to Shane?**
+
+If Browser has to reconstruct that from the inbox every session, too much context is burned before any real work begins.
+
+Update this file whenever a relationship becomes important enough to recur.
+
+---
+
+## Key People
+
+| Name | Role / Org | Relationship To Shane | Tone Guidance | Notes |
+|------|------------|-----------------------|---------------|-------|
+| `[Name]` | `[Role / Company]` | `[customer / vendor / teammate / partner / family / other]` | `[formal / warm / direct / casual / careful]` | `[anything Browser should know before drafting]` |
+
+Add rows here as the roster becomes real.
+
+---
+
+## Important Organizations
+
+| Organization | What It Is | Why It Matters | Main Contacts | Notes |
+|--------------|------------|----------------|---------------|-------|
+| `[Org]` | `[customer / vendor / platform / partner]` | `[reason]` | `[names]` | `[notes]` |
+
+---
+
+## Relationship Notes
+
+Use this section for the context that does not fit in a table:
+
+- long-standing relationships
+- sensitive dynamics
+- people who require extra care
+- people who prefer speed over warmth
+- people who need more background in replies
+
+Write short, factual notes.
+
+---
+
+## Mailboxes, Aliases, And Shared Surfaces
+
+| Surface | Purpose | Owner | Notes |
+|---------|---------|-------|-------|
+| `[mailbox or alias]` | `[what it is used for]` | `[who owns it]` | `[special handling notes]` |
+
+---
+
+## OneDrive And External Context Sources
+
+Use this section to point to the external truth surfaces Browser may need during email work.
+
+| Source | Path / Location | What Lives There | Notes |
+|--------|------------------|------------------|-------|
+| OneDrive | `[folder or shared location]` | `[reference docs / exports / project folders / email collections]` | `[when to check it]` |
+
+Do not bury the path in prose.
+Write it so a fresh Browser session can find it fast.
+
+---
+
+## Maintenance Rules
+
+- If a person becomes recurring, add them.
+- If tone guidance changes, update it here and in `WRITING_STYLE.md` if needed.
+- If a OneDrive or external source becomes the real source of truth for a thread or project, point to it here.
+- If something is unknown, write `UNKNOWN` instead of guessing.

--- a/skills/email-microsoft/RULES.md
+++ b/skills/email-microsoft/RULES.md
@@ -1,0 +1,74 @@
+# Email Rules
+
+**Purpose:** Capture the non-negotiables for Browser-managed email work.
+
+**Status:** Scaffold — incomplete rules mean draft-only mode
+
+---
+
+## Default Safety Rule
+
+Until this file is explicitly populated with live rules, Browser should operate in:
+
+**DRAFT_ONLY**
+
+That means:
+
+- summarize the thread
+- prepare the draft
+- flag anything sensitive
+- do not send unless Shane clearly approves
+
+---
+
+## Must Always Do
+
+- read `EMAIL_CONTEXT.md`, `WRITING_STYLE.md`, and `ACTIVE_THREADS.md` first
+- verify the actual thread before drafting
+- keep thread summaries factual
+- call out uncertainty instead of bluffing
+- update `ACTIVE_THREADS.md` when a live thread materially changes
+
+---
+
+## Must Never Do
+
+- invent relationships or prior promises
+- guess the tone from a single email fragment
+- send a draft as if it were approved when approval is unclear
+- let stale thread notes outrank the live thread itself
+
+---
+
+## Approval Gates
+
+Use this section to define when Browser can draft, when Browser can prepare replies, and when Browser must stop for approval.
+
+| Action | Allowed? | Notes |
+|--------|----------|-------|
+| Triage and summarize | `YES` | safe default |
+| Draft reply | `YES` | safe default unless thread is highly sensitive |
+| Send reply | `NO` until explicitly documented | populate when rules are agreed |
+| File or archive email | `NO` until explicitly documented | populate when workflow is agreed |
+
+---
+
+## Sensitive Thread Triggers
+
+Mark any of these as stop-and-escalate conditions once applicable:
+
+- billing disputes
+- legal or contract language
+- employee conflict
+- account credentials or security events
+- reputation-sensitive issues
+- emotionally charged threads
+
+Add concrete Phoenix-specific triggers here as they become known.
+
+---
+
+## Maintenance Rule
+
+If Shane states a rule in chat and it becomes recurring, write it here.
+Do not leave critical email governance in terminal-only memory.

--- a/skills/email-microsoft/SKILL.md
+++ b/skills/email-microsoft/SKILL.md
@@ -1,0 +1,62 @@
+# Skill: Email + Microsoft Operations
+
+**Agent:** BBB | **Capability:** Inbox triage, draft preparation, relationship-aware Microsoft email support
+
+## What It Is
+
+This skill gives Browser Echo a stable startup package for Microsoft email work so inbox sessions do not waste context reconstructing who people are, how Shane writes, what the rules are, or which threads are live.
+
+The job of this skill is not to replace judgment.
+The job is to front-load orientation so the context window gets spent on the actual email work.
+
+## When To Use It
+
+- Outlook or Microsoft 365 email work
+- Drafting or replying on Shane's behalf
+- Thread triage and status tracking
+- OneDrive-supported email context review
+- Contact and relationship reconstruction for inbox work
+
+## Read Order
+
+Before touching the inbox, read these in order:
+
+1. `RULES.md`
+2. `EMAIL_CONTEXT.md`
+3. `WRITING_STYLE.md`
+4. `ACTIVE_THREADS.md`
+
+Then check any live external surfaces:
+
+- Outlook / Microsoft 365 inbox
+- OneDrive folders or documents referenced in `EMAIL_CONTEXT.md`
+- the actual thread you are about to handle
+
+## Operating Rule
+
+If these files are thin, stale, or missing critical details:
+
+- do not fake context
+- do not send from confidence theater
+- draft, summarize, and escalate what is missing
+
+## What Good Looks Like
+
+- the key people are already identified
+- Shane's writing voice is already captured
+- the non-negotiables are explicit
+- live threads are tracked before the inbox opens
+- external context sources are pointed to, not guessed at
+
+## External Context Surfaces
+
+The repo should hold the orientation layer.
+Large email collections, exported reference material, or supporting documents can live outside the repo if needed, but they should be pointed to from these files clearly enough that a fresh Browser session knows where to look.
+
+OneDrive is the most likely external context surface for that.
+
+## Maintenance Rule
+
+Keep this skill lean.
+Add context to the four core files before creating more files.
+If a new recurring pattern emerges, add it only when it earns its place.

--- a/skills/email-microsoft/WRITING_STYLE.md
+++ b/skills/email-microsoft/WRITING_STYLE.md
@@ -1,0 +1,76 @@
+# Writing Style
+
+**Purpose:** Capture how Shane wants email drafts to sound so Browser is not imitating blindly from scattered threads.
+
+**Status:** Scaffold — populate before send-capable email work
+
+---
+
+## Default Voice
+
+Describe Shane's baseline email voice here.
+
+Suggested prompts:
+
+- Is the tone direct, warm, formal, efficient, or conversational?
+- Does he prefer short emails or fuller context?
+- Does he lead with the ask, the context, or the relationship?
+- Does he prefer softeners or straight language?
+
+Write the result as 5-10 bullets once known.
+
+---
+
+## Tone By Audience
+
+| Audience | Tone | Typical Length | Special Notes |
+|----------|------|----------------|---------------|
+| Internal team | `[tone]` | `[short / medium / long]` | `[notes]` |
+| Customers | `[tone]` | `[short / medium / long]` | `[notes]` |
+| Vendors / partners | `[tone]` | `[short / medium / long]` | `[notes]` |
+| Sensitive situations | `[tone]` | `[short / medium / long]` | `[notes]` |
+
+---
+
+## Subject Line Preferences
+
+Capture patterns like:
+
+- direct and descriptive
+- prefix with job or customer name
+- avoid vague subjects
+- include dates when scheduling matters
+
+---
+
+## Openings And Closings
+
+Use this section to note what sounds normal versus unnatural.
+
+Examples to capture once verified:
+
+- how Shane usually opens
+- whether he uses names every time
+- whether he signs with full name, first name, or something else
+- whether he uses thanks / appreciate it / let me know / etc.
+
+---
+
+## Phrases To Use
+
+- `[phrase or pattern]`
+
+## Phrases To Avoid
+
+- `[phrase or pattern]`
+
+---
+
+## Drafting Rule
+
+Until this file is meaningfully populated, Browser should assume:
+
+- drafts are allowed
+- sending requires explicit confirmation or clearly documented rules in `RULES.md`
+
+If the style is not known, write cleanly and label the uncertainty instead of performing confidence.


### PR DESCRIPTION
## What This Adds

This PR scaffolds a dedicated Microsoft email capability lane for Browser Echo so inbox work can start from stable context instead of reconstructing people, tone, rules, and live threads from scratch every session.

## Included

- `skills/email-microsoft/SKILL.md`
- `skills/email-microsoft/EMAIL_CONTEXT.md`
- `skills/email-microsoft/WRITING_STYLE.md`
- `skills/email-microsoft/RULES.md`
- `skills/email-microsoft/ACTIVE_THREADS.md`
- `knowledge/directory/EMAIL.md`

## Startup Integration

- Adds the email lane to `README.md`
- Adds email-specific orientation hooks to `bootstrap/ORIENTATION.md`
- Adds an active mission entry to `bootstrap/ACTIVE_MISSIONS.md`
- Logs the scaffolding pass in `ledger/SESSION_LOG.md`

## Operating Posture

This starts in `DRAFT_ONLY` mode until the context files are populated with:

- key people and relationships
- Shane's actual email voice
- explicit approval/send rules
- live threads
- OneDrive source paths for external context

## Why

Browser should spend context on the email work itself, not on rebuilding the same orientation every session.
